### PR TITLE
ci(chromatic): exit once uploaded

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,3 +32,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           buildScriptName: 'storybook:build'
+          exitOnceUploaded: true


### PR DESCRIPTION
Just a time saver in CI, since GitHub automatically checks the result in the PR.

See the note from Chromatic:
> ℹ Speed up Continuous Integration
Your project is linked to GitHub so Chromatic will report results there.
This means you can pass the --exit-once-uploaded flag to skip waiting for build results.
Read more here: chromatic.com/docs/cli#chromatic-options